### PR TITLE
CMake Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,4 +400,4 @@ build/
 out/
 
 Deploy/
-Pencil4LineForBlender/commitHash.h
+Pencil4LineForBlender/commitHash.*

--- a/.gitignore
+++ b/.gitignore
@@ -396,6 +396,7 @@ xcuserdata/
 *.xccheckout
 
 #CMAKE
+build/
 out/
 
 Deploy/

--- a/Pencil4LineForBlender/CMakeLists.txt
+++ b/Pencil4LineForBlender/CMakeLists.txt
@@ -2,6 +2,30 @@
 # プロジェクト専用ロジックはこちらです。
 #
 
+cmake_minimum_required(VERSION 3.15)
+project(Pencil4LineForBlender)
+
+if(MSVC OR XCODE)
+  set(CMAKE_CONFIGURATION_TYPES
+    Debug_Python39 Release_Python39
+    Debug_Python310 Release_Python310
+    Debug_Python311 Release_Python311
+    CACHE STRING "Configurations" FORCE
+  )
+endif()
+
+if(WIN32)
+    set(Suffix ".pyd")
+    set(OsName "win64")
+elseif(APPLE)
+    set(Suffix ".so")
+    set(OsName "mac")
+elseif(UNIX)
+    set(Suffix ".so")
+    set(OsName "linux")
+else()
+    message(FATAL_ERROR "Unsupported platform")
+endif()
 
 # ソースをこのプロジェクトの実行可能ファイルに追加します。
 add_library (Pencil4LineForBlender SHARED
@@ -110,7 +134,7 @@ set(IsDebug $<CONFIG:Debug_Python39,Debug_Python310,Debug_Python311>) # デバ�
 
 
 # 全般オプション
-set_property(TARGET Pencil4LineForBlender PROPERTY DEBUG_CONFIGURATIONS Debug_Python39,Debug_Python310) # どれがデバッグ構成なのかを指定
+set_property(TARGET Pencil4LineForBlender PROPERTY DEBUG_CONFIGURATIONS Debug_Python39,Debug_Python310,Debug_Python311) # どれがデバッグ構成なのかを指定
 set_target_properties(Pencil4LineForBlender PROPERTIES
   CXX_STANDARD 17
   OUTPUT_NAME pencil4line_for_blender_${OsName}_${PythonVer}
@@ -131,13 +155,13 @@ target_compile_definitions(Pencil4LineForBlender PRIVATE
   PYBIND_INCLUDE PENCIL4LINEFORBLENDER_EXPORTS _USRDLL
 )
 target_include_directories(Pencil4LineForBlender PRIVATE
-  ${CMAKE_SOURCE_DIR}/pybind11/include
-  ${CMAKE_SOURCE_DIR}/cereal/include
+  ${CMAKE_SOURCE_DIR}/../pybind11/include
+  ${CMAKE_SOURCE_DIR}/../cereal/include
   $<$<BOOL:${WIN32}>:$ENV{LOCALAPPDATA}/Programs/Python/Python${PythonVer}/include>
   $<$<NOT:$<BOOL:${WIN32}>>:/usr/include/python${PythonVerPoint}>
-  ${CMAKE_SOURCE_DIR}/blender/makesdna
-  ${CMAKE_SOURCE_DIR}/blender/makesrna
-  ${CMAKE_SOURCE_DIR}/blender/python
+  ${CMAKE_SOURCE_DIR}/../blender/makesdna
+  ${CMAKE_SOURCE_DIR}/../blender/makesrna
+  ${CMAKE_SOURCE_DIR}/../blender/python
   ${CMAKE_SOURCE_DIR}/Pencil4LineForBlender
 )
 if (${WIN32})
@@ -200,9 +224,9 @@ endif()
 # ビルド後の処理
 # ビルド結果をPackageフォルダにコピー
 # CMAKEコマンドラインのコピー機能を使うことによって各プラットフォームで動作する
-add_custom_command(TARGET Pencil4LineForBlender POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Pencil4LineForBlender> ${CMAKE_SOURCE_DIR}/Package/bin
-)
+# add_custom_command(TARGET Pencil4LineForBlender POST_BUILD
+#     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Pencil4LineForBlender> ${CMAKE_SOURCE_DIR}/Package/bin
+# )
 
 message("CMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}")
 message("CMAKE_HOST_SYSTEM_NAME=${CMAKE_HOST_SYSTEM_NAME}")

--- a/Pencil4LineForBlender/CMakeLists.txt
+++ b/Pencil4LineForBlender/CMakeLists.txt
@@ -248,6 +248,14 @@ message("WIN32=${WIN32}")
 message("LINUX=${LINUX}")
 message("UNIX=${UNIX}")
 
+install(TARGETS Pencil4LineForBlender
+  RUNTIME DESTINATION ${CMAKE_SOURCE_DIR}/Package/bin
+  LIBRARY DESTINATION ${CMAKE_SOURCE_DIR}/Package/bin
+)
+
+install(FILES ${CMAKE_SOURCE_DIR}/commitHash.txt
+  DESTINATION ${CMAKE_SOURCE_DIR}/Package/bin
+)
 
 # TODO: VisualStudioソリューションエクスプローラ上での論理フォルダ構成を設定（ファイルシステム上とは別のフォルダ構成を作れる）
 # set_target_properties(MyLibrary PROPERTIES FOLDER "MyFolder")

--- a/Pencil4LineForBlender/CMakeLists.txt
+++ b/Pencil4LineForBlender/CMakeLists.txt
@@ -10,6 +10,7 @@ if(MSVC OR XCODE)
     Debug_Python39 Release_Python39
     Debug_Python310 Release_Python310
     Debug_Python311 Release_Python311
+    Debug_Python311_450 Release_Python311_450
     CACHE STRING "Configurations" FORCE
   )
 endif()
@@ -128,21 +129,27 @@ endif()
 
 
 # よく使う値を変数に保存
-set(PythonVer $<IF:$<CONFIG:Debug_Python39,Release_Python39>,39,$<IF:$<CONFIG:Debug_Python310,Release_Python310>,310,311>>) # Pythonバージョン（ドット無し）
-set(PythonVerPoint $<IF:$<CONFIG:Debug_Python39,Release_Python39>,3.9,$<IF:$<CONFIG:Debug_Python310,Release_Python310>,3.10,3.11>>) # Pythonバージョン（ドット無し）
-set(IsDebug $<CONFIG:Debug_Python39,Debug_Python310,Debug_Python311>) # デバッグ構成かどうか　（TODO:プリセットの方で定義した方が取り回しが楽かもしれない）
+set(PythonVer
+  "$<$<CONFIG:Debug_Python39>:39>$<$<CONFIG:Release_Python39>:39>$<$<CONFIG:Debug_Python310>:310>$<$<CONFIG:Release_Python310>:310>$<$<CONFIG:Debug_Python311>:311>$<$<CONFIG:Release_Python311>:311>$<$<CONFIG:Debug_Python311_450>:311>$<$<CONFIG:Release_Python311_450>:311>"
+) # Pythonバージョン（ドット無し）
+set(PythonVerPoint
+  "$<$<CONFIG:Debug_Python39>:3.9>$<$<CONFIG:Release_Python39>:3.9>$<$<CONFIG:Debug_Python310>:3.10>$<$<CONFIG:Release_Python310>:3.10>$<$<CONFIG:Debug_Python311>:3.11>$<$<CONFIG:Release_Python311>:3.11>$<$<CONFIG:Debug_Python311_450>:3.11>$<$<CONFIG:Release_Python311_450>:3.11>"
+) # Pythonバージョン（ドット無し）
+set(IsDebug "$<OR:$<CONFIG:Debug_Python39>,$<CONFIG:Debug_Python310>,$<CONFIG:Debug_Python311>,$<CONFIG:Debug_Python311_450>>") # デバッグ構成かどうか　（TODO:プリセットの方で定義した方が取り回しが楽かもしれない）
 
+set(BlenderVerMin $<IF:$<CONFIG:Debug_Python311_450,Release_Python311_450>,_450,>)
 
 # 全般オプション
-set_property(TARGET Pencil4LineForBlender PROPERTY DEBUG_CONFIGURATIONS Debug_Python39,Debug_Python310,Debug_Python311) # どれがデバッグ構成なのかを指定
+set_property(TARGET Pencil4LineForBlender PROPERTY DEBUG_CONFIGURATIONS Debug_Python39,Debug_Python310,Debug_Python311,Debug_Python311_450) # どれがデバッグ構成なのかを指定
 set_target_properties(Pencil4LineForBlender PROPERTIES
   CXX_STANDARD 17
-  OUTPUT_NAME pencil4line_for_blender_${OsName}_${PythonVer}
+  OUTPUT_NAME pencil4line_for_blender_${OsName}_${PythonVer}${BlenderVerMin}
   PREFIX "" # デフォルトで「lib」が入っているので空にする
   SUFFIX ${Suffix}
   INTERPROCEDURAL_OPTIMIZATION_RELEASE_PYTHON39 TRUE # プログラム全体の最適化
   INTERPROCEDURAL_OPTIMIZATION_RELEASE_PYTHON310 TRUE
   INTERPROCEDURAL_OPTIMIZATION_RELEASE_PYTHON311 TRUE
+  INTERPROCEDURAL_OPTIMIZATION_RELEASE_PYTHON311_450 TRUE
 )
 
 
@@ -151,6 +158,7 @@ target_compile_definitions(Pencil4LineForBlender PRIVATE
   UNICODE _UNICODE
   $<$<BOOL:${WIN32}>:WIN32 _WINDOWS $<${IsDebug}:_DEBUG>>
   $<$<AND:$<NOT:$<BOOL:${WIN32}>>,${IsDebug}>:DEBUG=1>
+  $<$<OR:$<CONFIG:Debug_Python311_450>,$<CONFIG:Release_Python311_450>>:NEW_PROPERTY_RNA>
   PYTHON${PythonVer}
   PYBIND_INCLUDE PENCIL4LINEFORBLENDER_EXPORTS _USRDLL
 )
@@ -185,9 +193,11 @@ endif()
 set(CMAKE_SHARED_LINKER_FLAGS_DEBUG_PYTHON39 ${CMAKE_SHARED_LINKER_FLAGS_DEBUG})
 set(CMAKE_SHARED_LINKER_FLAGS_DEBUG_PYTHON310 ${CMAKE_SHARED_LINKER_FLAGS_DEBUG})
 set(CMAKE_SHARED_LINKER_FLAGS_DEBUG_PYTHON311 ${CMAKE_SHARED_LINKER_FLAGS_DEBUG})
+set(CMAKE_SHARED_LINKER_FLAGS_DEBUG_PYTHON311_450 ${CMAKE_SHARED_LINKER_FLAGS_DEBUG})
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE_PYTHON39 ${CMAKE_SHARED_LINKER_FLAGS_RELEASE})
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE_PYTHON310 ${CMAKE_SHARED_LINKER_FLAGS_RELEASE})
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE_PYTHON311 ${CMAKE_SHARED_LINKER_FLAGS_RELEASE})
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE_PYTHON311_450 ${CMAKE_SHARED_LINKER_FLAGS_RELEASE})
 if (${WIN32})
   target_link_directories(Pencil4LineForBlender PRIVATE $ENV{LOCALAPPDATA}/Programs/Python/Python${PythonVer}/libs)
   target_link_options(Pencil4LineForBlender PRIVATE

--- a/Pencil4LineForBlender/makeCommitHash.bat
+++ b/Pencil4LineForBlender/makeCommitHash.bat
@@ -1,4 +1,3 @@
-mkdir ../Package/bin
 for /f "usebackq tokens=*" %%i in (`git log -n 1 --pretty^=format:"%%H" -- . ../blender ../cereal ../pybind11 ../pencil4line_for_blender_mac`) do @set hash=%%i
-echo %hash% > ../Package/bin/commitHash.txt
+echo %hash% > commitHash.txt
 echo #define GIT_COMMIT_HASH "%hash%" > commitHash.h

--- a/Pencil4LineForBlender/makeCommitHash.bat
+++ b/Pencil4LineForBlender/makeCommitHash.bat
@@ -1,0 +1,4 @@
+mkdir ../Package/bin
+for /f "usebackq tokens=*" %%i in (`git log -n 1 --pretty^=format:"%%H" -- . ../blender ../cereal ../pybind11 ../pencil4line_for_blender_mac`) do @set hash=%%i
+echo %hash% > ../Package/bin/commitHash.txt
+echo #define GIT_COMMIT_HASH "%hash%" > commitHash.h


### PR DESCRIPTION
Hello, I have corrected CMakeList for version 4 and added missing target for Blender 4.50 and an install target for `${CMAKE_SOURCE_DIR}/Package/bin`
I do not have a device on OSX or Linux so I cannot test them. But Win32 is confirmed working python targets for release and debug. Please verify on your devices before merging.